### PR TITLE
closes #48;

### DIFF
--- a/flowplayer.hlsjs.js
+++ b/flowplayer.hlsjs.js
@@ -33,7 +33,7 @@
                 return typ.toLowerCase().indexOf("mpegurl") > -1;
             },
             hlsQualitiesSupport = function (conf) {
-                var hlsQualities = conf.clip.hlsQualities || conf.hlsQualities;
+                var hlsQualities = (conf.clip && conf.clip.hlsQualities) || conf.hlsQualities;
 
                 return support.inlineVideo &&
                         (hlsQualities === true ||


### PR DESCRIPTION
```javascript
<video id="video-0">
    <source type="application/x-mpegurl" src= "//somevideo.m3u8">
    <source type="video/webm; codecs='vp8, vorbis'" src="//anothervideo.webm">
  </video>
<script>
    flowplayer("#video-0")
</script>
```
